### PR TITLE
changing urllib to urllib2 (this is better to use with python3)

### DIFF
--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -29,7 +29,7 @@ import time
 import glob
 import shutil
 import hashlib
-import urllib.request, urllib.error, urllib.parse
+import urllib2
 from distutils.version import StrictVersion
 
 from cerbero.enums import Platform


### PR DESCRIPTION
Hi all, 

I've many problems to install urllib in ubuntu:
```
python setup.py build
Traceback (most recent call last):
  File "setup.py", line 6, in <module>
    from cerbero.utils import shell
  File "/home/rfaria/Projects/cerbero/cerbero/utils/shell.py", line 32, in <module>
    import urllib.request, urllib.error, urllib.parse
```
 and also, I've checked in stackoverflow that is recommended that is used urllib2. 

Regards, 