### PR TITLE
update remote url for orc-tool repository

### DIFF
--- a/recipes/build-tools/orc.recipe
+++ b/recipes/build-tools/orc.recipe
@@ -4,7 +4,7 @@
 class Recipe(recipe.Recipe):
     name = 'orc-tool'
     version = '0.4.28'
-    remotes = {'origin': 'https://gitlab.freedesktop.org/gstreamer/orc'}
+    remotes = {'origin': 'https://gitlab.freedesktop.org/gstreamer/orc.git'}
     commit = 'origin/master'
     licenses = [License.BSD_like]
     autoreconf = True


### PR DESCRIPTION
The remote url for orc-tool needs an extra `.git` at the end, otherwise cerbero bootstrap fails.