### PR TITLE
cmake: add '.' to configure_tpl

### DIFF
--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -519,7 +519,7 @@ class CMake (MakefilesBase):
                     '-DCMAKE_INSTALL_INCLUDEDIR=%(prefix)s/include ' \
                     '%(options)s -DCMAKE_BUILD_TYPE=Release '\
                     '-DCMAKE_FIND_ROOT_PATH=$CERBERO_PREFIX '\
-                    '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true '
+                    '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true .'
 
     @async_modify_environment
     async def configure(self):


### PR DESCRIPTION
When building taglib:
    cerbero build taglib
error:
    CMake Error: No source or binary directory provided

This is because no build directory specified, so add '.' for it.

Signed-off-by: dudengke <pinganddu90@gmail.com>