### PR TITLE
Fix distro check

### DIFF
--- a/cerbero/utils/__init__.py
+++ b/cerbero/utils/__init__.py
@@ -247,7 +247,7 @@ Terminating.''', file=sys.stderr)
                 distro_version = DistroVersion.UBUNTU_DISCO
             elif distro_version in ['eoan']:
                 distro_version = DistroVersion.UBUNTU_EOAN
-            elif distro_version in ['focal'] or (distro_version[0] == 'u' and d[1].startswith('20.')):
+            elif distro_version in ['focal'] or (distro_version.startswith('u') and d[1].startswith('20.')):
                 distro_version = DistroVersion.UBUNTU_FOCAL
             elif d[1].startswith('6.'):
                 distro_version = DistroVersion.DEBIAN_SQUEEZE


### PR DESCRIPTION
When distro_version is blank string, the error has occured below.

```
$ ./cerbero-uninstalled bootstrap
Traceback (most recent call last):
  File "<string>", line 19, in <module>
  File "/tmp/cerbero/cerbero/main.py", line 19, in <module>
    from cerbero import hacks
  File "/tmp/cerbero/cerbero/hacks.py", line 99, in <module>
    from cerbero.utils.shell import new_call as shell_call
  File "/tmp/cerbero/cerbero/utils/shell.py", line 51, in <module>
    PLATFORM = system_info()[0]
  File "/tmp/cerbero/cerbero/utils/__init__.py", line 250, in system_info
    elif distro_version in ['focal'] or (distro_version[0] == 'u' and d[1].startswith('20.')):
IndexError: string index out of range
```